### PR TITLE
Expanded Profile View

### DIFF
--- a/PokemonPals/Controllers/CaughtPokemonController.cs
+++ b/PokemonPals/Controllers/CaughtPokemonController.cs
@@ -45,6 +45,7 @@ namespace PokemonPals.Controllers
                                                             .Where(cp => cp.isOwned == true)
                                                             .Where(cp => cp.UserId == currentUser.Id)
                                                             .Where(cp => cp.isHidden == false)
+                                                            .Where(cp => cp.isOwned == true)
                                                             .OrderBy(cp => cp.PokemonId)
                                                             .ToListAsync();
 

--- a/PokemonPals/Controllers/UsersController.cs
+++ b/PokemonPals/Controllers/UsersController.cs
@@ -74,15 +74,33 @@ namespace PokemonPals.Controllers
                 return NotFound();
             }
 
+            //Gets a list of all the Pokemon the current user has caught (and have not been soft-deleted)
+            List<CaughtPokemon> listOfUserCaughtPokemon = await _context.CaughtPokemon
+                                                            .Where(cp => cp.UserId == currentUser.Id)
+                                                            .Where(cp => cp.isHidden == false)
+                                                            .ToListAsync();
+
+            //Loops through the list of Pokemon the user owns, so that we can get their IDs
+            foreach (CaughtPokemon caughtPokemon in listOfUserCaughtPokemon)
+            {
+                //If this list does not already contain the species of Pokemon we're currently looking at...
+                if (!model.CurrentUserCollection.Contains(caughtPokemon.PokemonId))
+                {
+                    //...add it to the list of IDs
+                    model.CurrentUserCollection.Add(caughtPokemon.PokemonId);
+                }
+            }
+
             List<Pokemon> AllPokemon = await _context.Pokemon.ToListAsync();
             model.AllPokemonCount = AllPokemon.Count();
 
             model.UserCollection = await _context.CaughtPokemon
                                             .Include(cp => cp.Pokemon)
                                             .Include(cp => cp.Gender)
+                                            .Include(cp => cp.User)
                                             .Where(cp => cp.isOwned == true)
                                             .Where(cp => cp.isHidden == false)
-                                            .Where(cp => cp.UserId == id)
+                                            .Where(cp => cp.User.UserName == id)
                                             .OrderBy(cp => cp.PokemonId)
                                             .ToListAsync();
 
@@ -97,24 +115,112 @@ namespace PokemonPals.Controllers
             model.FavoritePokemon = await _context.CaughtPokemon
                                             .Include(cp => cp.Pokemon)
                                             .Include(cp => cp.Gender)
+                                            .Include(cp => cp.User)
                                             .Where(cp => cp.isHidden == false)
                                             .Where(cp => cp.isOwned == true)
-                                            .Where(cp => cp.UserId == id)
+                                            .Where(cp => cp.User.UserName == id)
                                             .Where(cp => cp.isFavorite == true)
                                             .OrderBy(cp => cp.PokemonId)
-                                            .Take(10)
+                                            .Take(5)
                                             .ToListAsync();
 
             model.TradePokemon = await _context.CaughtPokemon
                                             .Include(cp => cp.Pokemon)
                                             .Include(cp => cp.Gender)
+                                            .Include(cp => cp.User)
                                             .Where(cp => cp.isHidden == false)
                                             .Where(cp => cp.isOwned == true)
-                                            .Where(cp => cp.UserId == id)
+                                            .Where(cp => cp.User.UserName == id)
                                             .Where(cp => cp.isTradeOpen == true)
                                             .OrderBy(cp => cp.PokemonId)
-                                            .Take(10)
+                                            .Take(5)
                                             .ToListAsync();
+
+            return View(model);
+        }
+
+        [Authorize]
+        public async Task<IActionResult> Trades(string id)
+        {
+            UserCollectionViewModel model = new UserCollectionViewModel();
+            ApplicationUser currentUser = await GetCurrentUserAsync();
+            model.ViewedUser = await _userManager.Users.FirstOrDefaultAsync(user => user.UserName == id);
+
+            if(model.ViewedUser == null)
+            {
+                return NotFound();
+            }
+
+            model.ViewedCollection = await _context.CaughtPokemon
+                                                    .Include(cp => cp.User)
+                                                    .Include(cp => cp.Gender)
+                                                    .Include(cp => cp.Pokemon)
+                                                    .Where(cp => cp.User.UserName == id)
+                                                    .Where(cp => cp.isHidden == false)
+                                                    .Where(cp => cp.isOwned == true)
+                                                    .Where(cp => cp.isTradeOpen == true)
+                                                    .OrderBy(cp => cp.PokemonId)
+                                                    .ToListAsync();
+
+            //Gets a list of all the Pokemon the current user has caught (and have not been soft-deleted)
+            List<CaughtPokemon> listOfUserCaughtPokemon = await _context.CaughtPokemon
+                                                            .Where(cp => cp.UserId == currentUser.Id)
+                                                            .Where(cp => cp.isHidden == false)
+                                                            .ToListAsync();
+
+            //Loops through the list of Pokemon the user owns, so that we can get their IDs
+            foreach (CaughtPokemon caughtPokemon in listOfUserCaughtPokemon)
+            {
+                //If this list does not already contain the species of Pokemon we're currently looking at...
+                if (!model.CurrentUserCollection.Contains(caughtPokemon.PokemonId))
+                {
+                    //...add it to the list of IDs
+                    model.CurrentUserCollection.Add(caughtPokemon.PokemonId);
+                }
+            }
+
+            return View(model);
+        }
+
+        [Authorize]
+        public async Task<IActionResult> Favorites(string id)
+        {
+            UserCollectionViewModel model = new UserCollectionViewModel();
+            ApplicationUser currentUser = await GetCurrentUserAsync();
+            model.ViewedUser = await _userManager.Users.FirstOrDefaultAsync(user => user.UserName == id);
+
+            if (model.ViewedUser == null)
+            {
+                return NotFound();
+            }
+
+            model.ViewedCollection = await _context.CaughtPokemon
+                                                    .Include(cp => cp.User)
+                                                    .Include(cp => cp.Gender)
+                                                    .Include(cp => cp.Pokemon)
+                                                    .Where(cp => cp.User.UserName == id)
+                                                    .Where(cp => cp.isHidden == false)
+                                                    .Where(cp => cp.isOwned == true)
+                                                    .Where(cp => cp.isFavorite == true)
+                                                    .OrderBy(cp => cp.PokemonId)
+                                                    .ToListAsync();
+
+            //Gets a list of all the Pokemon the current user has caught (and have not been soft-deleted)
+            List<CaughtPokemon> listOfUserCaughtPokemon = await _context.CaughtPokemon
+                                                            .Where(cp => cp.UserId == currentUser.Id)
+                                                            .Where(cp => cp.isHidden == false)
+                                                            .ToListAsync();
+
+            //Loops through the list of Pokemon the user owns, so that we can get their IDs
+            foreach (CaughtPokemon caughtPokemon in listOfUserCaughtPokemon)
+            {
+                //If this list does not already contain the species of Pokemon we're currently looking at...
+                if (!model.CurrentUserCollection.Contains(caughtPokemon.PokemonId))
+                {
+                    //...add it to the list of IDs
+                    model.CurrentUserCollection.Add(caughtPokemon.PokemonId);
+                }
+            }
 
             return View(model);
         }

--- a/PokemonPals/Models/ViewModels/UserCollectionViewModel.cs
+++ b/PokemonPals/Models/ViewModels/UserCollectionViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PokemonPals.Models.ViewModels
+{
+    public class UserCollectionViewModel
+    {
+        public ApplicationUser ViewedUser = new ApplicationUser();
+        public List<CaughtPokemon> ViewedCollection = new List<CaughtPokemon>();
+        public List<int> CurrentUserCollection = new List<int>();
+    }
+}

--- a/PokemonPals/Models/ViewModels/UserProfileViewModel.cs
+++ b/PokemonPals/Models/ViewModels/UserProfileViewModel.cs
@@ -12,6 +12,7 @@ namespace PokemonPals.Models.ViewModels
         public List<CaughtPokemon> UserCollection = new List<CaughtPokemon>();
         public int AllPokemonCount = 0;
         public List<int> CaughtPokemonIDs = new List<int>();
+        public List<int> CurrentUserCollection = new List<int>();
         public List<CaughtPokemon> FavoritePokemon = new List<CaughtPokemon>();
         public List<CaughtPokemon> TradePokemon = new List<CaughtPokemon>();
     }

--- a/PokemonPals/Views/Shared/_Layout.cshtml
+++ b/PokemonPals/Views/Shared/_Layout.cshtml
@@ -7,11 +7,11 @@
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />
     <link rel="stylesheet" href="~/css/Global.css" />
+    <link rel="stylesheet" href="~/css/Profile.css" />
     <link rel="stylesheet" href="~/css/Dex.css" />
     <link rel="stylesheet" href="~/css/DexDetails.css" />
     <link rel="stylesheet" href="~/css/CaughtCreate.css" />
     <link rel="stylesheet" href="~/css/Collection.css" />
-    <link rel="stylesheet" href="~/css/Profile.css" />
 </head>
 <body>
     <header>

--- a/PokemonPals/Views/Users/Favorites.cshtml
+++ b/PokemonPals/Views/Users/Favorites.cshtml
@@ -1,0 +1,62 @@
+﻿@model PokemonPals.Models.ViewModels.UserCollectionViewModel;
+
+@{
+    ViewData["Title"] = $"{@Model.ViewedUser.UserName}'s Favorites";
+
+}
+
+<div class="global-header">
+    <h1>@Model.ViewedUser.UserName's Favorites</h1>
+</div>
+
+<hr />
+@{
+    if (Model.ViewedCollection.Count() == 0)
+    {
+    <div class="profile-center">
+        This user does not have any Favorite Pokemon!
+    </div>
+    }
+    else
+    {
+        <div class="collection-container">
+            @foreach (CaughtPokemon PokemonInCollection in Model.ViewedCollection)
+            {
+                string favoriteCaught = "";
+                if (Model.CurrentUserCollection.Contains(PokemonInCollection.PokemonId))
+                {
+                    favoriteCaught = "dex-caught";
+                }
+
+                //A card for displaying a single Pokemon
+            <div class="collection-card @favoriteCaught">
+                @*The sprite image of the Pokemon. When clicked, it takes the user to an Edit page for this Pokemon*@
+                    <img class="sprite-img" src=@PokemonInCollection.Pokemon.RBSpriteURL />
+
+                <div class="collection-card-info">
+                    @*Shows the Pokemon's Nickname (or their species name, if this caught Pokemon has no nickname)*@
+                    @if (PokemonInCollection.Nickname != null)
+                    {
+                        <h4 class="dex-details-red-text row">
+                                @PokemonInCollection.Nickname
+                        </h4>
+                    }
+                    else
+                    {
+                        <h4 class="dex-details-red-text row">
+                                @PokemonInCollection.Pokemon.Name
+                        </h4>
+                    }
+
+                    @*Shows the Pokemon's level and CP properties*@
+                    <div class="dex-details-red-text row">Level @PokemonInCollection.Level</div>
+
+                    <div class="dex-details-red-text row">
+                        @PokemonInCollection.Gender.Name, @PokemonInCollection.CP CP
+                    </div>
+                </div>
+            </div>
+            }
+        </div>
+    }
+}

--- a/PokemonPals/Views/Users/Profile.cshtml
+++ b/PokemonPals/Views/Users/Profile.cshtml
@@ -71,16 +71,26 @@
     <div class="col-sm-8 profile-collection-col">
 
 
-        <div class="profile-info">
-            <h3 class="profile-header">Favorites</h3>
+        <div>
+            <h3 class="profile-header">
+                <a asp-controller="Users" asp-action="Favorites" asp-route-id=@Model.ViewedUser.UserName>
+                    Favorites
+                </a>
+            </h3>
             @{
                 if (Model.FavoritePokemon.Count() != 0)
                 {
                     <div class="profile-card-container">
                         @foreach (CaughtPokemon SingleFavorite in Model.FavoritePokemon)
                         {
+                            string favoriteCaught = "";
+                            if (Model.CurrentUserCollection.Contains(SingleFavorite.PokemonId))
+                            {
+                                favoriteCaught = "dex-caught";
+                            }
+
                             //A card for displaying a single Pokemon
-                            <div class="profile-card">
+                            <div class="profile-card @favoriteCaught">
                                 @*The sprite image of the Pokemon.*@
                                 <img class="sprite-img" src=@SingleFavorite.Pokemon.RBSpriteURL />
 
@@ -121,16 +131,26 @@
                 }
             }
         </div>
-        <div class="profile-info">
-            <h3 class="profile-header">Open for trade</h3>
+        <div>
+            <h3 class="profile-header">
+                <a asp-controller="Users" asp-action="Trades" asp-route-id=@Model.ViewedUser.UserName>
+                    Open for Trade
+                </a>
+            </h3>
             @{
                 if (Model.TradePokemon.Count() != 0)
                 {
                     <div class="profile-card-container">
                         @foreach (CaughtPokemon SingleTrade in Model.TradePokemon)
                         {
+                            string tradeCaught = "";
+                            if (Model.CurrentUserCollection.Contains(SingleTrade.PokemonId))
+                            {
+                                tradeCaught = "dex-caught";
+                            }
+
                             //A card for displaying a single Pokemon
-                            <div class="profile-card">
+                            <div class="profile-card @tradeCaught">
                                 @*The sprite image of the Pokemon.*@
                                 <img class="sprite-img" src=@SingleTrade.Pokemon.RBSpriteURL />
 

--- a/PokemonPals/Views/Users/Trades.cshtml
+++ b/PokemonPals/Views/Users/Trades.cshtml
@@ -1,0 +1,62 @@
+﻿@model PokemonPals.Models.ViewModels.UserCollectionViewModel;
+
+@{
+    ViewData["Title"] = $"{@Model.ViewedUser.UserName}'s Trades";
+
+}
+
+<div class="global-header">
+    <h1>@Model.ViewedUser.UserName's Open for Trade Pokemon</h1>
+</div>
+
+<hr />
+@{
+    if (Model.ViewedCollection.Count() == 0)
+    {
+    <div class="profile-center">
+        This user does not have any Pokemon up for trade!
+    </div>
+    }
+    else
+    {
+        <div class="collection-container">
+            @foreach (CaughtPokemon PokemonInCollection in Model.ViewedCollection)
+            {
+                string tradeCaught = "";
+                if (Model.CurrentUserCollection.Contains(PokemonInCollection.PokemonId))
+                {
+                    tradeCaught = "dex-caught";
+                }
+
+                //A card for displaying a single Pokemon
+                <div class="collection-card @tradeCaught">
+                    @*The sprite image of the Pokemon. When clicked, it takes the user to an Edit page for this Pokemon*@
+                    <img class="sprite-img" src=@PokemonInCollection.Pokemon.RBSpriteURL />
+
+                    <div class="collection-card-info">
+                        @*Shows the Pokemon's Nickname (or their species name, if this caught Pokemon has no nickname)*@
+                        @if (PokemonInCollection.Nickname != null)
+                        {
+                            <h4 class="dex-details-red-text row">
+                                @PokemonInCollection.Nickname
+                            </h4>
+                        }
+                        else
+                        {
+                            <h4 class="dex-details-red-text row">
+                                @PokemonInCollection.Pokemon.Name
+                            </h4>
+                        }
+
+                        @*Shows the Pokemon's level and CP properties*@
+                        <div class="dex-details-red-text row">Level @PokemonInCollection.Level</div>
+
+                        <div class="dex-details-red-text row">
+                            @PokemonInCollection.Gender.Name, @PokemonInCollection.CP CP
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+}

--- a/PokemonPals/wwwroot/css/Profile.css
+++ b/PokemonPals/wwwroot/css/Profile.css
@@ -42,7 +42,7 @@
 
 .profile-card {
     border-radius: 8px;
-    background-color: #ff9f9a;
+    background-color: #ffe8e7;
     padding: 1em;
     flex-basis: 18%;
     box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
@@ -84,4 +84,8 @@
     text-align: center;
     margin-left: auto;
     margin-right: auto;
+}
+
+.uncaught {
+    background-color: #ffe8e7;
 }


### PR DESCRIPTION
# Description
-When a User views another user's Profile, the Pokemon they currently own are highlighted. Pokemon they don't own (but ARE a part of another user's collection) are shown in a lighter colored card.
-When viewing another User's profile, a User can now click "Favorites" or "Open for Trade" to view ALL Pokemon the other User owns that are either a Favorite or Open for Trade.

# Related Tickets
[Caught Pokemon will be highlighted on other user's page](https://trello.com/c/LqGqiI0Q/38-caught-pokemon-will-be-highlighted-on-other-users-page)
[Tag sections can be clicked to show an expanded view](https://trello.com/c/P11aL86i/23-tag-sections-can-be-clicked-to-show-an-expanded-view)