### PR TITLE
Search for Trade Pokemon

### DIFF
--- a/PokemonPals/Controllers/TradesController.cs
+++ b/PokemonPals/Controllers/TradesController.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PokemonPals.Data;
+using PokemonPals.Models;
+using PokemonPals.Models.ViewModels;
+
+namespace PokemonPals.Controllers
+{
+    public class TradesController : Controller
+    {
+        private readonly ApplicationDbContext _context;
+
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public TradesController(ApplicationDbContext context, UserManager<ApplicationUser> userManager)
+        {
+            _context = context;
+            _userManager = userManager;
+        }
+
+
+        //A method for fetching the currently logged in user
+        private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
+
+        public async Task<IActionResult> Requests(string searchString)
+        {
+            TradeRequestViewModel model = new TradeRequestViewModel();
+            ApplicationUser currentUser = await GetCurrentUserAsync();
+
+            ViewBag.SearchString = searchString;
+
+            model.SearchResults = await _context.CaughtPokemon
+                                            .Include(cp => cp.User)
+                                            .Include(cp => cp.Pokemon)
+                                            .Include(cp => cp.Gender)
+                                            .Where(cp => cp.isTradeOpen == true)
+                                            .Where(cp => cp.isHidden == false)
+                                            .Where(cp => cp.isOwned == true)
+                                            .Where(cp => cp.UserId != currentUser.Id)
+                                            .OrderByDescending(cp => cp.DateCaught)
+                                            .ToListAsync();
+
+            if (searchString != null && searchString != "")
+            {
+                model.SearchResults = model.SearchResults
+                                        .Where(cp => cp.Pokemon.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+                                        .ToList();
+            }
+            else
+            {
+                model.SearchResults = model.SearchResults
+                                        .Take(10)
+                                        .ToList();
+            }
+
+            return View(model);
+        }
+    }
+}

--- a/PokemonPals/Controllers/TradesController.cs
+++ b/PokemonPals/Controllers/TradesController.cs
@@ -48,7 +48,8 @@ namespace PokemonPals.Controllers
             if (searchString != null && searchString != "")
             {
                 model.SearchResults = model.SearchResults
-                                        .Where(cp => cp.Pokemon.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+                                        .Where(cp => (cp.Nickname ?? "").Contains(searchString, StringComparison.OrdinalIgnoreCase)
+                                       || cp.Pokemon.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase))
                                         .ToList();
             }
             else

--- a/PokemonPals/Models/ViewModels/TradeRequestViewModel.cs
+++ b/PokemonPals/Models/ViewModels/TradeRequestViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PokemonPals.Models.ViewModels
+{
+    public class TradeRequestViewModel
+    {
+        public List<CaughtPokemon> SearchResults = new List<CaughtPokemon>();
+    }
+}

--- a/PokemonPals/Views/CaughtPokemon/Collection.cshtml
+++ b/PokemonPals/Views/CaughtPokemon/Collection.cshtml
@@ -116,7 +116,7 @@
         //if the list passed to this view is empty, we're going to prompt the user to add a Pokemon to their collection
         if (Model.Count() == 0)
         {
-            <h4>You don't have any Pokemon! Go <a asp-controller="Pokemon" asp-action="Dex">add some!</a></h4>
+            <h4>You don't have any Pokemon! <a asp-controller="Pokemon" asp-action="Dex">Go catch some!</a></h4>
         }
         //Loops through the CaughtPokemon passed to the View
         foreach (CaughtPokemon PokemonInCollection in Model)

--- a/PokemonPals/Views/Shared/_Layout.cshtml
+++ b/PokemonPals/Views/Shared/_Layout.cshtml
@@ -15,14 +15,14 @@
 </head>
 <body>
     <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
+        <nav class="navbar navbar-expand-lg navbar-toggleable-sm border-bottom box-shadow mb-3">
             <div class="container">
                 <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">Pokemon Pals</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
+                    <img class="pokeball-img-nav" src="@Url.Content("~/images/pokeball.png")"/>
                 </button>
-                <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
+                <div class="navbar-collapse collapse flex-sm-row-reverse">
                     <partial name="_LoginPartial" />
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
@@ -36,6 +36,9 @@
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Users" asp-action="UserSearch">Users</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" asp-area="" asp-controller="Trades" asp-action="Requests">Trade Requests</a>
                         </li>
                     </ul>
                 </div>

--- a/PokemonPals/Views/Trades/Requests.cshtml
+++ b/PokemonPals/Views/Trades/Requests.cshtml
@@ -1,0 +1,81 @@
+﻿@model PokemonPals.Models.ViewModels.TradeRequestViewModel;
+
+@{
+    ViewData["Title"] = $"Trade Requests";
+    string searchString = ViewBag.SearchString;
+}
+
+<div class="global-header">
+    <h1>Trade Requests</h1>
+</div>
+<div class="row collection-sort profile-center">
+    @using (Html.BeginForm())
+    {
+        <p>
+            Search by species name: <br />
+            @Html.TextBox("searchString") <input type="submit" value="Search" />
+        </p>
+    }
+</div>
+<hr />
+
+@{
+    if (searchString == null || searchString == "")
+    {
+        <div class="profile-center">
+            <h4 class="dex-details-red-text">Recently Caught Pokemon Open for Trade</h4>
+            <p>Please enter a search query to lookup specific Pokemon to trade!</p>
+        </div>
+    }
+    else
+    {
+        <div class="profile-center">
+            <h4 class="dex-details-red-text">Results for "@searchString"</h4>
+        </div>
+    }
+    if (Model.SearchResults.Count() == 0)
+    {
+        <div class="profile-center">
+            <p>Sorry, no Pokemon could be found. Please try again!</p>
+        </div>
+    }
+    else
+    {
+        <div class="collection-container">
+            @foreach (CaughtPokemon PokemonInSearch in Model.SearchResults)
+            {
+                <div class="collection-card">
+                    @*The sprite image of the Pokemon. When clicked, it takes the user to an Edit page for this Pokemon*@
+                    <img class="sprite-img" src=@PokemonInSearch.Pokemon.RBSpriteURL />
+
+                    <div class="collection-card-info">
+                        @*Shows the Pokemon's Nickname (or their species name, if this caught Pokemon has no nickname)*@
+                        @if (PokemonInSearch.Nickname != null)
+                        {
+                            <h4 class="dex-details-red-text row">
+                                @PokemonInSearch.Nickname
+                            </h4>
+                        }
+                        else
+                        {
+                            <h4 class="dex-details-red-text row">
+                                @PokemonInSearch.Pokemon.Name
+                            </h4>
+                        }
+
+                        @*Shows the Pokemon's level and CP properties*@
+                        <div class="dex-details-red-text row">Level @PokemonInSearch.Level</div>
+
+                        <div class="dex-details-red-text row">
+                            @PokemonInSearch.Gender.Name, @PokemonInSearch.CP CP
+                        </div>
+                        <div class="row">
+                            <a class="dex-details-white-text" asp-controller="Users" asp-action="Profile" asp-route-id=@PokemonInSearch.User.UserName>Owned by @PokemonInSearch.User.UserName</a>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+}
+

--- a/PokemonPals/Views/Trades/Requests.cshtml
+++ b/PokemonPals/Views/Trades/Requests.cshtml
@@ -12,7 +12,7 @@
     @using (Html.BeginForm())
     {
         <p>
-            Search by species name: <br />
+            Search by nickname or species name: <br />
             @Html.TextBox("searchString") <input type="submit" value="Search" />
         </p>
     }

--- a/PokemonPals/Views/Users/Favorites.cshtml
+++ b/PokemonPals/Views/Users/Favorites.cshtml
@@ -29,7 +29,7 @@
                 }
 
                 //A card for displaying a single Pokemon
-            <div class="collection-card @favoriteCaught">
+            <div class="profile-card-expand @favoriteCaught">
                 @*The sprite image of the Pokemon. When clicked, it takes the user to an Edit page for this Pokemon*@
                     <img class="sprite-img" src=@PokemonInCollection.Pokemon.RBSpriteURL />
 

--- a/PokemonPals/Views/Users/Trades.cshtml
+++ b/PokemonPals/Views/Users/Trades.cshtml
@@ -29,7 +29,7 @@
                 }
 
                 //A card for displaying a single Pokemon
-                <div class="collection-card @tradeCaught">
+                <div class="profile-card-expand @tradeCaught">
                     @*The sprite image of the Pokemon. When clicked, it takes the user to an Edit page for this Pokemon*@
                     <img class="sprite-img" src=@PokemonInCollection.Pokemon.RBSpriteURL />
 

--- a/PokemonPals/Views/Users/UserSearch.cshtml
+++ b/PokemonPals/Views/Users/UserSearch.cshtml
@@ -9,13 +9,13 @@
     <h1>User Search</h1>
 </div>
 <div class="row collection-sort profile-center">
-        @using (Html.BeginForm())
-        {
-            <p>
-                Search by username: <br />
-                @Html.TextBox("searchString") <input type="submit" value="Search" />
-            </p>
-        }
+    @using (Html.BeginForm())
+    {
+        <p>
+            Search by username: <br />
+            @Html.TextBox("searchString") <input type="submit" value="Search" />
+        </p>
+    }
 </div>
 <hr />
 
@@ -23,46 +23,50 @@
     if (searchString == null || searchString == "")
     {
         <div class="profile-center">
-            <p>Please enter a search query to lookup other users!</p>
+            <h4 class="dex-details-red-text">All Users</h4>
+            <p>Please enter a search query to lookup specific users!</p>
         </div>
     }
     else
     {
-        if (Model.Count() == 0)
-        {
-            <div class="profile-center">
-                <p>Sorry, no users match your search. Please try again!</p>
-            </div>
-        }
-        else
-        {
-            <div>
-                @foreach (ApplicationUser UserInSearch in Model)
-                {
-                    //A card that will show a user's profile image, username, and other info
-                    <div class="pokemon-card row">
-                        <div class="col">
+        <div class="profile-center">
+            <h4 class="dex-details-red-text">Results for "@searchString"</h4>
+        </div>
+    }
+    if (Model.Count() == 0)
+    {
+        <div class="profile-center">
+            <p>Sorry, no users found. Please try again!</p>
+        </div>
+    }
+    else
+    {
+        <div>
+            @foreach (ApplicationUser UserInSearch in Model)
+            {
+                //A card that will show a user's profile image, username, and other info
+                <div class="pokemon-card row">
+                    <div class="col">
+                        <a asp-controller="Users" asp-action="Profile" asp-route-id="@UserInSearch.UserName">
+                            <img class="sprite-img" src=@UserInSearch.Avatar.ImageURL />
+                        </a>
+                    </div>
+
+
+                    <div class="col-sm-10">
+                        <h4 class="dex-details-red-text row">
                             <a asp-controller="Users" asp-action="Profile" asp-route-id="@UserInSearch.UserName">
-                                <img class="sprite-img" src=@UserInSearch.Avatar.ImageURL />
+                                @UserInSearch.UserName
                             </a>
-                        </div>
 
-
-                        <div class="col-sm-10">
-                            <h4 class="dex-details-red-text row">
-                                <a asp-controller="Users" asp-action="Profile" asp-route-id="@UserInSearch.UserName">
-                                    @UserInSearch.UserName
-                                </a>
-
-                            </h4>
-                            <div class="dex-details-white-text row">
-                                @UserInSearch.Description
-                            </div>
+                        </h4>
+                        <div class="dex-details-white-text row">
+                            @UserInSearch.Description
                         </div>
                     </div>
-                }
-            </div>
-        }
+                </div>
+            }
+        </div>
     }
 }
 

--- a/PokemonPals/wwwroot/css/Global.css
+++ b/PokemonPals/wwwroot/css/Global.css
@@ -36,6 +36,24 @@
     filter: drop-shadow(0 4px 12px rgba(0,0,0,0.3));
 }
 
+.pokeball-img-nav {
+    width: 20px;
+    height: 20px;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 10px;
+    margin-top: 10px;
+    -webkit-filter: drop-shadow(0 4px 8px rgba(0,0,0,0.3));
+    filter: drop-shadow(0 4px 8px rgba(0,0,0,0.3));
+}
+
+    .pokeball-img-nav:hover {
+        transform: scale(1.15);
+        -webkit-filter: drop-shadow(0 4px 12px rgba(0,0,0,0.3));
+        filter: drop-shadow(0 4px 12px rgba(0,0,0,0.3));
+    }
+
 .global-btn {
     background-color: #e0332a;
     color: #ffe8e7;

--- a/PokemonPals/wwwroot/css/Profile.css
+++ b/PokemonPals/wwwroot/css/Profile.css
@@ -86,6 +86,18 @@
     margin-right: auto;
 }
 
-.uncaught {
+.profile-card-expand {
+    border-radius: 8px;
     background-color: #ffe8e7;
+    padding: 1em;
+    flex-basis: 18%;
+    box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+    margin: 1em;
+    margin-left: 6px;
+    margin-right: 6px;
 }
+
+    .profile-card-expand:hover {
+        transform: scale(1.05);
+        box-shadow: 0 4px 16px 0 rgba(0,0,0,0.2);
+    }


### PR DESCRIPTION
# Description
A new link, "Trade Requests," has been added to the NavBar. This page will hold any info relating to Trade Requests that users can send each other. In this ticket, the only feature added is the ability to search for Pokemon to trade.
When first loading the page, the 10 most recently caught Pokemon that have been marked "Open for Trade" (by someone other than the current User) will be displayed. The User can enter a search query to search by nickname or species name, and get results back. Each result is displayed with a clickable link to its owner's profile.
 In the future, Users will be able to click a Pokemon's name to generate a Trade Request message.

# Related Tickets
[Users can search for a Pokemon available for trade](https://trello.com/c/ibMikIC3/37-users-can-search-for-a-pokemon-available-for-trade)