### PR TITLE
View Trade Requests

### DIFF
--- a/PokemonPals/Controllers/TradesController.cs
+++ b/PokemonPals/Controllers/TradesController.cs
@@ -49,6 +49,7 @@ namespace PokemonPals.Controllers
                                                 .ThenInclude(tr => tr.Pokemon)
                                             .Take(3)
                                             .Where(tr => tr.DesiredPokemon.UserId == currentUser.Id)
+                                            .OrderByDescending(tr => tr.DateSent)
                                             .ToListAsync();
 
             model.OutgoingRequests = await _context.TradeRequest
@@ -66,6 +67,7 @@ namespace PokemonPals.Controllers
                                                 .ThenInclude(tr => tr.Pokemon)
                                             .Take(3)
                                             .Where(tr => tr.OfferedPokemon.UserId == currentUser.Id)
+                                            .OrderByDescending(tr => tr.DateSent)
                                             .ToListAsync();
 
             model.SearchResults = await _context.CaughtPokemon
@@ -238,10 +240,11 @@ namespace PokemonPals.Controllers
 
                 newTradeRequest.DesiredPokemonId = passedModel.DesiredPokemonId;
                 newTradeRequest.OfferedPokemonId = passedModel.OfferedPokemonId;
-                newTradeRequest.Comment = passedModel.Comment;
+                newTradeRequest.Comment = passedModel.Comment.Replace("'", "''");
+                newTradeRequest.isOpen = true;
 
-                _context.Database.ExecuteSqlCommand(
-        $"INSERT INTO TradeRequest (DesiredPokemonId, OfferedPokemonId, Comment) VALUES ({passedModel.DesiredPokemonId}, {passedModel.OfferedPokemonId}, {passedModel.Comment})");
+                string sqlCommand = $"INSERT INTO TradeRequest (DesiredPokemonId, OfferedPokemonId, Comment, isOpen, DateSent, DateCompleted) VALUES ({newTradeRequest.DesiredPokemonId}, {newTradeRequest.OfferedPokemonId}, '{newTradeRequest.Comment}', 1, '{DateTime.Now}', NULL)";
+                _context.Database.ExecuteSqlCommand(sqlCommand);
 
                 return RedirectToAction("Index");
             }

--- a/PokemonPals/Controllers/TradesController.cs
+++ b/PokemonPals/Controllers/TradesController.cs
@@ -34,6 +34,40 @@ namespace PokemonPals.Controllers
 
             ViewBag.SearchString = searchString;
 
+            model.IncomingRequests = await _context.TradeRequest
+                                            .Include(tr => tr.DesiredPokemon)
+                                                .ThenInclude(tr => tr.User)
+                                            .Include(tr => tr.DesiredPokemon)
+                                                .ThenInclude(tr => tr.Gender)
+                                            .Include(tr => tr.DesiredPokemon)
+                                                .ThenInclude(tr => tr.Pokemon)
+                                            .Include(tr => tr.OfferedPokemon)
+                                                .ThenInclude(tr => tr.User)
+                                            .Include(tr => tr.OfferedPokemon)
+                                                .ThenInclude(tr => tr.Gender)
+                                            .Include(tr => tr.OfferedPokemon)
+                                                .ThenInclude(tr => tr.Pokemon)
+                                            .Take(3)
+                                            .Where(tr => tr.DesiredPokemon.UserId == currentUser.Id)
+                                            .ToListAsync();
+
+            model.OutgoingRequests = await _context.TradeRequest
+                                            .Include(tr => tr.DesiredPokemon)
+                                                .ThenInclude(tr => tr.User)
+                                            .Include(tr => tr.DesiredPokemon)
+                                                .ThenInclude(tr => tr.Gender)
+                                            .Include(tr => tr.DesiredPokemon)
+                                                .ThenInclude(tr => tr.Pokemon)
+                                            .Include(tr => tr.OfferedPokemon)
+                                                .ThenInclude(tr => tr.User)
+                                            .Include(tr => tr.OfferedPokemon)
+                                                .ThenInclude(tr => tr.Gender)
+                                            .Include(tr => tr.OfferedPokemon)
+                                                .ThenInclude(tr => tr.Pokemon)
+                                            .Take(3)
+                                            .Where(tr => tr.OfferedPokemon.UserId == currentUser.Id)
+                                            .ToListAsync();
+
             model.SearchResults = await _context.CaughtPokemon
                                             .Include(cp => cp.User)
                                             .Include(cp => cp.Pokemon)

--- a/PokemonPals/Data/ApplicationDbContext.cs
+++ b/PokemonPals/Data/ApplicationDbContext.cs
@@ -22,20 +22,5 @@ namespace PokemonPals.Data
         public DbSet<Gender> Gender { get; set; }
         public DbSet<Pokemon> Pokemon { get; set; }
         public DbSet<TradeRequest> TradeRequest { get; set; }
-
-        //protected override void OnModelCreating(ModelBuilder modelBuilder)
-        //{
-        //    base.OnModelCreating(modelBuilder);
-
-        //    modelBuilder.Entity<CaughtPokemon>()
-        //        .HasMany(cp => cp.TradeRequests)
-        //        .WithOne(tr => tr.DesiredPokemon)
-        //        .OnDelete(DeleteBehavior.Restrict);
-
-        //    modelBuilder.Entity<CaughtPokemon>()
-        //        .HasMany(cp => cp.TradeRequests)
-        //        .WithOne(tr => tr.OfferedPokemon)
-        //        .OnDelete(DeleteBehavior.Restrict);
-        //}
     }
 }

--- a/PokemonPals/Data/Migrations/20201009141940_TradeRequestDates.Designer.cs
+++ b/PokemonPals/Data/Migrations/20201009141940_TradeRequestDates.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PokemonPals.Data;
 
 namespace PokemonPals.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201009141940_TradeRequestDates")]
+    partial class TradeRequestDates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -413,7 +415,7 @@ namespace PokemonPals.Data.Migrations
                         .HasColumnType("nvarchar(120)")
                         .HasMaxLength(120);
 
-                    b.Property<DateTime?>("DateCompleted")
+                    b.Property<DateTime>("DateCompleted")
                         .HasColumnType("datetime2");
 
                     b.Property<DateTime>("DateSent")

--- a/PokemonPals/Data/Migrations/20201009141940_TradeRequestDates.cs
+++ b/PokemonPals/Data/Migrations/20201009141940_TradeRequestDates.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace PokemonPals.Data.Migrations
+{
+    public partial class TradeRequestDates : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DateCompleted",
+                table: "TradeRequest",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DateSent",
+                table: "TradeRequest",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<bool>(
+                name: "isOpen",
+                table: "TradeRequest",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DateCompleted",
+                table: "TradeRequest");
+
+            migrationBuilder.DropColumn(
+                name: "DateSent",
+                table: "TradeRequest");
+
+            migrationBuilder.DropColumn(
+                name: "isOpen",
+                table: "TradeRequest");
+        }
+    }
+}

--- a/PokemonPals/Data/Migrations/20201009143757_DateCompletedNull.Designer.cs
+++ b/PokemonPals/Data/Migrations/20201009143757_DateCompletedNull.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PokemonPals.Data;
 
 namespace PokemonPals.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201009143757_DateCompletedNull")]
+    partial class DateCompletedNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PokemonPals/Data/Migrations/20201009143757_DateCompletedNull.cs
+++ b/PokemonPals/Data/Migrations/20201009143757_DateCompletedNull.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace PokemonPals.Data.Migrations
+{
+    public partial class DateCompletedNull : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DateCompleted",
+                table: "TradeRequest",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DateCompleted",
+                table: "TradeRequest",
+                type: "datetime2",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldNullable: true);
+        }
+    }
+}

--- a/PokemonPals/Models/TradeRequest.cs
+++ b/PokemonPals/Models/TradeRequest.cs
@@ -19,7 +19,7 @@ namespace PokemonPals.Models
         [StringLength(120)]
         public string Comment { get; set; }
         public DateTime DateSent { get; set; }
-        public DateTime DateCompleted { get; set; }
+        public DateTime? DateCompleted { get; set; }
         public Boolean isOpen { get; set; }
     }
 }

--- a/PokemonPals/Models/TradeRequest.cs
+++ b/PokemonPals/Models/TradeRequest.cs
@@ -18,5 +18,8 @@ namespace PokemonPals.Models
         public CaughtPokemon OfferedPokemon { get; set; } = new CaughtPokemon();
         [StringLength(120)]
         public string Comment { get; set; }
+        public DateTime DateSent { get; set; }
+        public DateTime DateCompleted { get; set; }
+        public Boolean isOpen { get; set; }
     }
 }

--- a/PokemonPals/Models/ViewModels/TradeIndexViewModel.cs
+++ b/PokemonPals/Models/ViewModels/TradeIndexViewModel.cs
@@ -9,5 +9,7 @@ namespace PokemonPals.Models.ViewModels
     {
         public List<CaughtPokemon> SearchResults { get; set; } = new List<CaughtPokemon>();
         public List<int> CurrentUserCollection { get; set; } = new List<int>();
+        public List<TradeRequest> IncomingRequests { get; set; } = new List<TradeRequest>();
+        public List<TradeRequest> OutgoingRequests { get; set; } = new List<TradeRequest>();
     }
 }

--- a/PokemonPals/Views/Shared/_Layout.cshtml
+++ b/PokemonPals/Views/Shared/_Layout.cshtml
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="~/css/site.css" />
     <link rel="stylesheet" href="~/css/Global.css" />
     <link rel="stylesheet" href="~/css/Profile.css" />
+    <link rel="stylesheet" href="~/css/Trade.css" />
     <link rel="stylesheet" href="~/css/Dex.css" />
     <link rel="stylesheet" href="~/css/DexDetails.css" />
     <link rel="stylesheet" href="~/css/CaughtCreate.css" />

--- a/PokemonPals/Views/Trades/Index.cshtml
+++ b/PokemonPals/Views/Trades/Index.cshtml
@@ -32,9 +32,33 @@
                             <img class="sprite-img" src=@SingleIncomingRequest.OfferedPokemon.Pokemon.RBSpriteURL />
                         </div>
                         <div class="dex-details-red-text">Trade your @desiredNickname for @offeredNickname</div>
-                        <div>
-                            <a class="dex-details-black-text" asp-controller="Users" asp-action="profile" asp-route-id=@SingleIncomingRequest.OfferedPokemon.User.UserName>Sent by @SingleIncomingRequest.OfferedPokemon.User.UserName</a>
+                        <div class="dex-details-black-text">
+                            Sent by <a class="dex-details-black-text" asp-controller="Users" asp-action="profile" asp-route-id=@SingleIncomingRequest.OfferedPokemon.User.UserName>@SingleIncomingRequest.OfferedPokemon.User.UserName</a> on @SingleIncomingRequest.DateSent.ToShortDateString()
                         </div>
+                        <div class="dex-details-red-text">
+                            @SingleIncomingRequest.Comment
+                        </div>
+                        @{
+                            if (SingleIncomingRequest.isOpen)
+                            {
+                                <div class="dex-details-black-text">
+                                    Open
+                                </div>
+                            }
+                            else if (!SingleIncomingRequest.isOpen && SingleIncomingRequest.DateCompleted == null)
+                            {
+                                <div class="dex-details-black-text">
+                                    Rejected
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="dex-details-black-text">
+                                    Completed
+                                </div>
+                            }
+
+                        }
                     </div>
                 }
             }
@@ -60,9 +84,33 @@
                             <img class="sprite-img" src=@SingleOutgoingRequest.DesiredPokemon.Pokemon.RBSpriteURL />
                         </div>
                         <div class="dex-details-red-text">Trade your @offeredNickname for @desiredNickname</div>
-                        <div>
-                            <a class="dex-details-black-text" asp-controller="Users" asp-action="profile" asp-route-id=@SingleOutgoingRequest.DesiredPokemon.User.UserName>Sent to @SingleOutgoingRequest.DesiredPokemon.User.UserName</a>
+                        <div class="dex-details-black-text">
+                            Sent to <a class="dex-details-black-text" asp-controller="Users" asp-action="profile" asp-route-id=@SingleOutgoingRequest.DesiredPokemon.User.UserName>@SingleOutgoingRequest.DesiredPokemon.User.UserName</a> on @SingleOutgoingRequest.DateSent.ToShortDateString()
                         </div>
+                        <div class="dex-details-red-text">
+                            @SingleOutgoingRequest.Comment
+                        </div>
+                        @{
+                            if (SingleOutgoingRequest.isOpen)
+                            {
+                                <div class="dex-details-black-text">
+                                    Open
+                                </div>
+                            }
+                            else if (!SingleOutgoingRequest.isOpen && SingleOutgoingRequest.DateCompleted == null)
+                            {
+                                <div class="dex-details-black-text">
+                                    Rejected
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="dex-details-black-text">
+                                    Completed
+                                </div>
+                            }
+
+                        }
                     </div>
                 }
             }

--- a/PokemonPals/Views/Trades/Index.cshtml
+++ b/PokemonPals/Views/Trades/Index.cshtml
@@ -8,90 +8,155 @@
 <div class="global-header">
     <h1>Trade Requests</h1>
 </div>
-<div class="row collection-sort profile-center">
-    @using (Html.BeginForm())
-    {
-        <p>
-            Search by nickname or species name: <br />
-            @Html.TextBox("searchString") <input type="submit" value="Search" />
-        </p>
-    }
-</div>
-<hr />
 
-@{
-    if (searchString == null || searchString == "")
-    {
-        <div class="global-header">
-            <h4 class="dex-details-red-text">Recently Caught Pokemon Open for Trade</h4>
-            <p>Please enter a search query to lookup specific Pokemon to trade!</p>
-        </div>
-    }
-    else
-    {
-        <div class="profile-center">
-            <h4 class="dex-details-red-text">Results for "@searchString"</h4>
-        </div>
-    }
-    if (Model.SearchResults.Count() == 0)
-    {
-        <div class="profile-center">
-            <p>Sorry, no Pokemon could be found. Please try again!</p>
-        </div>
-    }
-    else
-    {
-        <div class="collection-container">
-            @foreach (CaughtPokemon PokemonInSearch in Model.SearchResults)
+<div class="profile-row">
+    <div class="col profile-info-col">
+        <div class="global-header profile-text">
+            <h4>Incoming Requests</h4>
+            @if (Model.IncomingRequests.Count() == 0)
             {
-                string tradeCaught = "";
-                @if (Model.CurrentUserCollection.Contains(PokemonInSearch.PokemonId))
-                {
-                    tradeCaught = "dex-caught";
-                }
-                <div class="profile-card-expand @tradeCaught">
-                    @*The sprite image of the Pokemon. When clicked, it takes the user to an Edit page for this Pokemon*@
-                    <a asp-controller="Trades" asp-action="StartRequest" asp-route-id=@PokemonInSearch.Id>
-                        <img class="sprite-img" src=@PokemonInSearch.Pokemon.RBSpriteURL />
-                    </a>
-
-                    <div class="profile-card-info">
-                        @*Shows the Pokemon's Nickname (or their species name, if this caught Pokemon has no nickname)*@
-                        @if (PokemonInSearch.Nickname != null)
-                        {
-                            <h4 class="dex-details-red-text row">
-                                <a asp-controller="Trades" asp-action="StartRequest" asp-route-id=@PokemonInSearch.Id>
-                                    @PokemonInSearch.Nickname
-                                </a>
-                            </h4>
-                        }
-                        else
-                        {
-                            <h4 class="dex-details-red-text row">
-                                <a asp-controller="Trades" asp-action="StartRequest" asp-route-id=@PokemonInSearch.Id>
-                                    @PokemonInSearch.Pokemon.Name
-                                </a>
-                            </h4>
-
-                        }
-
-                        @*Shows the Pokemon's level and CP properties*@
-                        <div class="dex-details-red-text row">Level @PokemonInSearch.Level</div>
-
-                        <div class="dex-details-red-text row">
-                            @PokemonInSearch.Gender.Name, @PokemonInSearch.CP CP
-                        </div>
-                        <div class="row">
-                            <a class="dex-details-black-text" asp-controller="Users" asp-action="Profile" asp-route-id=@PokemonInSearch.User.UserName>Owned by @PokemonInSearch.User.UserName</a>
-                        </div>
-                    </div>
-
-                    <a asp-controller="Trades" asp-action="StartRequest" asp-route-id=@PokemonInSearch.Id>
-                        <button class="btn trade-btn">Request Trade</button>
-                    </a>
+                <div class="trade-request-card">
+                    <p>You have no incoming trade requests!</p>
                 </div>
             }
+            else
+            {
+                foreach (TradeRequest SingleIncomingRequest in @Model.IncomingRequests)
+                {
+                    string desiredNickname = (SingleIncomingRequest.DesiredPokemon.Nickname != null && SingleIncomingRequest.DesiredPokemon.Nickname != "") ? SingleIncomingRequest.DesiredPokemon.Nickname : SingleIncomingRequest.DesiredPokemon.Pokemon.Name;
+                    string offeredNickname = (SingleIncomingRequest.OfferedPokemon.Nickname != null && SingleIncomingRequest.OfferedPokemon.Nickname != "") ? SingleIncomingRequest.OfferedPokemon.Nickname : SingleIncomingRequest.OfferedPokemon.Pokemon.Name;
+
+                    <div class="trade-request-card">
+                        <div class="row">
+                            <img class="sprite-img" src=@SingleIncomingRequest.DesiredPokemon.Pokemon.RBSpriteURL />
+                            <img class="sprite-img" src=@SingleIncomingRequest.OfferedPokemon.Pokemon.RBSpriteURL />
+                        </div>
+                        <div class="dex-details-red-text">Trade your @desiredNickname for @offeredNickname</div>
+                        <div>
+                            <a class="dex-details-black-text" asp-controller="Users" asp-action="profile" asp-route-id=@SingleIncomingRequest.OfferedPokemon.User.UserName>Sent by @SingleIncomingRequest.OfferedPokemon.User.UserName</a>
+                        </div>
+                    </div>
+                }
+            }
         </div>
-    }
-}
+        <div class="global-header profile-text">
+            <h4>Outgoing Requests</h4>
+            @if (Model.OutgoingRequests.Count() == 0)
+            {
+                <div class="trade-request-card">
+                    You have no outgoing trade requests!
+                </div>
+            }
+            else
+            {
+                foreach (TradeRequest SingleOutgoingRequest in @Model.OutgoingRequests)
+                {
+                    string desiredNickname = (SingleOutgoingRequest.DesiredPokemon.Nickname != null && SingleOutgoingRequest.DesiredPokemon.Nickname != "") ? SingleOutgoingRequest.DesiredPokemon.Nickname : SingleOutgoingRequest.DesiredPokemon.Pokemon.Name;
+                    string offeredNickname = (SingleOutgoingRequest.OfferedPokemon.Nickname != null && SingleOutgoingRequest.OfferedPokemon.Nickname != "") ? SingleOutgoingRequest.OfferedPokemon.Nickname : SingleOutgoingRequest.OfferedPokemon.Pokemon.Name;
+
+                    <div class="trade-request-card">
+                        <div class="row">
+                            <img class="sprite-img" src=@SingleOutgoingRequest.OfferedPokemon.Pokemon.RBSpriteURL />
+                            <img class="sprite-img" src=@SingleOutgoingRequest.DesiredPokemon.Pokemon.RBSpriteURL />
+                        </div>
+                        <div class="dex-details-red-text">Trade your @offeredNickname for @desiredNickname</div>
+                        <div>
+                            <a class="dex-details-black-text" asp-controller="Users" asp-action="profile" asp-route-id=@SingleOutgoingRequest.DesiredPokemon.User.UserName>Sent to @SingleOutgoingRequest.DesiredPokemon.User.UserName</a>
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+    </div>
+    <div class="col-sm-8 profile-collection-col">
+        <div class="collection-sort profile-center">
+            @using (Html.BeginForm())
+            {
+                <p>
+                    Search by nickname or species name: <br />
+                    @Html.TextBox("searchString") <input type="submit" value="Search" />
+                </p>
+            }
+        </div>
+        <hr />
+
+        @{
+            if (searchString == null || searchString == "")
+            {
+                <div class="global-header">
+                    <h4 class="dex-details-red-text">Recently Caught Pokemon Open for Trade</h4>
+                    <p>Please enter a search query to lookup specific Pokemon to trade!</p>
+                </div>
+            }
+            else
+            {
+                <div class="profile-center">
+                    <h4 class="dex-details-red-text">Results for "@searchString"</h4>
+                </div>
+            }
+            if (Model.SearchResults.Count() == 0)
+            {
+                <div class="profile-center">
+                    <p>Sorry, no Pokemon could be found. Please try again!</p>
+                </div>
+            }
+            else
+            {
+                <div class="collection-container">
+                    @foreach (CaughtPokemon PokemonInSearch in Model.SearchResults)
+                    {
+                        string tradeCaught = "";
+                        @if (Model.CurrentUserCollection.Contains(PokemonInSearch.PokemonId))
+                        {
+                            tradeCaught = "dex-caught";
+                        }
+                        <div class="profile-card-expand @tradeCaught">
+                            @*The sprite image of the Pokemon. When clicked, it takes the user to an Edit page for this Pokemon*@
+                            <a asp-controller="Trades" asp-action="StartRequest" asp-route-id=@PokemonInSearch.Id>
+                                <img class="sprite-img" src=@PokemonInSearch.Pokemon.RBSpriteURL />
+                            </a>
+
+                            <div class="profile-card-info">
+                                @*Shows the Pokemon's Nickname (or their species name, if this caught Pokemon has no nickname)*@
+                                @if (PokemonInSearch.Nickname != null)
+                                {
+                                    <h4 class="dex-details-red-text row">
+                                        <a asp-controller="Trades" asp-action="StartRequest" asp-route-id=@PokemonInSearch.Id>
+                                            @PokemonInSearch.Nickname
+                                        </a>
+                                    </h4>
+                                }
+                                else
+                                {
+                                    <h4 class="dex-details-red-text row">
+                                        <a asp-controller="Trades" asp-action="StartRequest" asp-route-id=@PokemonInSearch.Id>
+                                            @PokemonInSearch.Pokemon.Name
+                                        </a>
+                                    </h4>
+
+                                }
+
+                                @*Shows the Pokemon's level and CP properties*@
+                                <div class="dex-details-red-text row">Level @PokemonInSearch.Level</div>
+
+                                <div class="dex-details-red-text row">
+                                    @PokemonInSearch.Gender.Name, @PokemonInSearch.CP CP
+                                </div>
+                                <div class="row">
+                                    <a class="dex-details-black-text" asp-controller="Users" asp-action="Profile" asp-route-id=@PokemonInSearch.User.UserName>Owned by @PokemonInSearch.User.UserName</a>
+                                </div>
+                            </div>
+
+                            <a asp-controller="Trades" asp-action="StartRequest" asp-route-id=@PokemonInSearch.Id>
+                                <button class="btn trade-btn">Request Trade</button>
+                            </a>
+                        </div>
+                    }
+                </div>
+            }
+        }
+    </div>
+
+
+</div>
 

--- a/PokemonPals/Views/Trades/Index.cshtml
+++ b/PokemonPals/Views/Trades/Index.cshtml
@@ -16,7 +16,7 @@
             @if (Model.IncomingRequests.Count() == 0)
             {
                 <div class="trade-request-card">
-                    <p>You have no incoming trade requests!</p>
+                    You have no incoming trade requests!
                 </div>
             }
             else

--- a/PokemonPals/Views/Users/Profile.cshtml
+++ b/PokemonPals/Views/Users/Profile.cshtml
@@ -69,8 +69,6 @@
     </div>
 
     <div class="col-sm-8 profile-collection-col">
-
-
         <div>
             <h3 class="profile-header">
                 <a asp-controller="Users" asp-action="Favorites" asp-route-id=@Model.ViewedUser.UserName>

--- a/PokemonPals/wwwroot/css/Profile.css
+++ b/PokemonPals/wwwroot/css/Profile.css
@@ -68,6 +68,7 @@
 
 .profile-card-info{
     flex: 1;
+    min-width: 134px;
 }
 
 .profile-header {

--- a/PokemonPals/wwwroot/css/Trade.css
+++ b/PokemonPals/wwwroot/css/Trade.css
@@ -1,0 +1,16 @@
+﻿.trade-request-card {
+    border-radius: 8px;
+    background-color: #ffe8e7;
+    padding: 1em;
+    box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+    margin: 1em;
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+    .trade-request-card:hover {
+        transform: scale(1.05);
+        box-shadow: 0 4px 16px 0 rgba(0,0,0,0.2);
+    }


### PR DESCRIPTION
# Description
-When a User views the Trade Requests screen, they now see two sections on the left: Incoming and Outgoing Trade Requests
-Both sections show the three most recent Trade Requests of that type
-The Trade Request cards shown house: images for the Pokemon desired and offered, the nicknames of both Pokemon, who sent the request/who you sent the request to, the comments attached, the date it was sent, and whether the request is Open/Completed/Rejected.
-In the future, the titles of these sections can be clicked to bring us to a view showing EVERY request a user has of that type
-In the future, clicking a Trade Request card will show more details, including all details on each Pokemon, and will allow the user to accept/reject/comment on a Request

-The TradeRequest resource has been updated to have properties for isOpen, DateSent, and DateCompleted

# Related Tickets
[Users can view incoming trade requests](https://trello.com/c/qwnuDpiB/31-users-can-view-incoming-trade-requests)
[Users can view outgoing trade requests](https://trello.com/c/ZyFc5dJv/47-users-can-view-outgoing-trade-requests)
[Add isOpen, DateSent, and DateCompleted to Trade Requests](https://trello.com/c/vPvf2MfG/48-add-isopen-datesent-and-datecompleted-to-trade-requests)